### PR TITLE
Fix/judges not deleted in mode change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file.
 
+## [1.0.2-20240623]
+### Fixed
+- エンドレスモードをプレイ後にデイリーモードをプレイするとシェア テキストが6件以上になる不具合の修正
+
 ## [1.0.1-20240623]
 ### Fixed
 - Misskeyにシェアする時に改行が1行多い問題を修正

--- a/js/kivodle.js
+++ b/js/kivodle.js
@@ -93,6 +93,7 @@ function switchDailyMode() {
     }
 
     endlessModeFlg = false;
+    judges.splice(0);
     setup();
 }
 
@@ -111,6 +112,7 @@ function switchEndlessMode() {
     }
 
     endlessModeFlg = true;
+    judges.splice(0);
     setup();
 }
 
@@ -221,6 +223,7 @@ function endGame(isHit) {
         // エンドレスモードで正解した時の処理
         $('#infoButtonArea').append($('<button>').attr('id', 'nextButton').html('次の問題へ'));
         $('#nextButton').on('click', function () { setup(true) });
+        judges.splice(0);
     }
 }
 


### PR DESCRIPTION
[エンドレスモードをプレイ後にデイリーモードをプレイするとシェアテキストが6件以上になる不具合の修正](https://github.com/TaktstockJp/Kivodle/commit/c5e0df38942a20b6bce1066be6284026176a5357)