### PR TITLE
スマートフォンで表示した際にテーブルが横スクロールになるように変更

### DIFF
--- a/css/kivodle.css
+++ b/css/kivodle.css
@@ -51,16 +51,13 @@ body {
 }
 
 #logoArea {
-    position: relative;
-    height: 200px;
+    margin-bottom: 30px;
+	text-align: center;
 }
 
 #logo {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    text-align: center;
+    width: 100%;
+	max-width: 450px;
 }
 
 #infoArea {
@@ -93,6 +90,10 @@ body {
     text-align: center;
 }
 
+#checkArea {
+	overflow-x: auto;
+}
+
 #selectGuess {
     display: inline-block;
     border-radius: 5px;
@@ -119,6 +120,11 @@ table td {
     border: solid 1px #008f99;
 }
 
+table th, 
+table td:not(.studentNameCol) {
+	text-wrap: nowrap;
+}
+
 th {
     background-color: #a5f9ff;
 }
@@ -129,6 +135,8 @@ td {
 
 .studentNameCol {
     width: 24%;
+	position: sticky;
+	left: 5px;
 }
 
 .weaponTypeCol {

--- a/js/kivodle.js
+++ b/js/kivodle.js
@@ -252,7 +252,7 @@ function prependTableRow(guessed, judgeObj) {
     const $newRow = $('<tr>');
     const cellBase = '<td></td>';
 
-    const $studentCell = $(cellBase).addClass(judgeObj.isHit).html(guessed.studentName);
+    const $studentCell = $(cellBase).addClass(judgeObj.isHit + ' studentNameCol').html(guessed.studentName);
     $newRow.append($studentCell);
     const $weaponCell = $(cellBase).addClass(judgeObj.isSameWeapon).html(weapons[guessed.data.weapon]);
     $newRow.append($weaponCell);


### PR DESCRIPTION
## やったこと
- テーブルが画面に納まりきらないときに横スクロールになるように変更
  - ただし，キャラ名の列のみ位置を固定．
- 全てのth，キャラ名以外のtdを折り返さないように変更
- 快適に横スクロールさせるためにロゴがはみ出さないように修正