### PR TITLE
生徒検索時の入力内容がひらがな以外の場合の検索ロジックの修正

### DIFF
--- a/js/kivodle.js
+++ b/js/kivodle.js
@@ -65,6 +65,7 @@ function pageLoad() {
                 const editionNameHiragana = convertToHiragana(item.editionName);
                 const term = convertToHiragana(search);
 
+                if (item.text === search) return 3; 
                 if (uniqueNameHiragana === term) return 2;
                 if (editionNameHiragana === term) return 2;
                 if (item.uniqueName.includes(search)) return 1;

--- a/js/kivodle.js
+++ b/js/kivodle.js
@@ -67,6 +67,8 @@ function pageLoad() {
 
                 if (uniqueNameHiragana === term) return 2;
                 if (editionNameHiragana === term) return 2;
+                if (item.uniqueName.includes(search)) return 1;
+                if (item.editionName.includes(search)) return 1;
                 if (uniqueNameHiragana.includes(term)) return 1;
                 if (editionNameHiragana.includes(term)) return 1;
                 return 0;


### PR DESCRIPTION
Issue #121 の修正

Tom Selectに渡す検索ロジックを以下のように修正
- 入力内容がひらがな変換前の生徒名・衣装名と部分一致しているかの判定を追加
- 入力内容がひらがな変換前のテキストと完全一致しているかの判定を追加